### PR TITLE
feat: Add MCP progress notifications for long-running operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Interactive Demo Prompt** — Flagship MCP demonstration
   - `sqlite_demo` prompt for interactive capability walkthrough
   - Guides through data creation, querying, and insight capture
+- **MCP Progress Notifications (2025-11-25)** — Real-time progress updates for long-running operations
+  - New `src/utils/progress-utils.ts` module with `sendProgress()` and `buildProgressContext()` utilities
+  - Extended `RequestContext` interface with optional `server` and `progressToken` fields
+  - `sqlite_restore`: 3-phase progress (prepare → restore → verify)
+  - `sqlite_optimize`: Dynamic multi-phase progress (start → reindex → analyze → complete)
+  - `sqlite_vacuum`: 2-phase progress (start → complete)
+  - Notifications are best-effort and require client support for `progressToken` in `_meta`
 
 ### Changed
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -259,6 +259,18 @@ export interface RequestContext {
 
   /** Request ID for tracing */
   requestId: string;
+
+  /**
+   * MCP Server instance for sending progress notifications.
+   * Only available when running in HTTP/SSE transport with stateful sessions.
+   */
+  server?: unknown;
+
+  /**
+   * Progress token from client request _meta (MCP 2025-11-25).
+   * If present, the client has requested progress updates.
+   */
+  progressToken?: string | number;
 }
 
 // =============================================================================

--- a/src/utils/progress-utils.ts
+++ b/src/utils/progress-utils.ts
@@ -1,0 +1,103 @@
+/**
+ * db-mcp - Progress Notification Utilities
+ *
+ * Utilities for sending MCP progress notifications during long-running operations.
+ * Follows MCP 2025-11-25 specification for notifications/progress.
+ */
+
+import type { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import type { RequestContext } from "../types/index.js";
+
+/** Progress token from client request _meta */
+export type ProgressToken = string | number;
+
+/** Context required to send progress notifications */
+export interface ProgressContext {
+  /** MCP Server instance for sending notifications */
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
+  server: Server;
+  /** Progress token from request _meta (if client requested progress) */
+  progressToken?: ProgressToken;
+}
+
+/**
+ * Build a ProgressContext from RequestContext if progress fields are available.
+ * Returns undefined if the context doesn't have progress support.
+ */
+export function buildProgressContext(
+  ctx: RequestContext | undefined,
+): ProgressContext | undefined {
+  if (ctx?.server === undefined || ctx.progressToken === undefined) {
+    return undefined;
+  }
+  return {
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    server: ctx.server as Server,
+    progressToken: ctx.progressToken,
+  };
+}
+
+/**
+ * Send a progress notification to the client.
+ *
+ * Only sends if a progressToken was provided in the original request.
+ * Silently no-ops if no token was provided.
+ *
+ * @param ctx - Progress context with server and optional token
+ * @param progress - Current progress value (e.g., items processed)
+ * @param total - Optional total value for percentage calculation
+ * @param message - Optional human-readable status message
+ */
+export async function sendProgress(
+  ctx: ProgressContext | undefined,
+  progress: number,
+  total?: number,
+  message?: string,
+): Promise<void> {
+  // Early return if no context, no progressToken, or no server
+  if (ctx === undefined) return;
+  if (ctx.progressToken === undefined) return;
+
+  try {
+    // Build notification payload per MCP spec
+    const notification = {
+      method: "notifications/progress" as const,
+      params: {
+        progressToken: ctx.progressToken,
+        progress,
+        ...(total !== undefined && { total }),
+        ...(message !== undefined && message !== "" && { message }),
+      },
+    };
+
+    // Send via server's notification method
+    await ctx.server.notification(notification);
+  } catch {
+    // Non-critical: progress notifications are best-effort
+    // Don't let notification failures break the operation
+  }
+}
+
+/**
+ * Create a progress reporter function for batch operations.
+ *
+ * @param ctx - Progress context
+ * @param total - Total number of items to process
+ * @param throttle - Report every N items (default: 10)
+ * @returns Async function to call on each item processed
+ */
+export function createBatchProgressReporter(
+  ctx: ProgressContext | undefined,
+  total: number,
+  throttle = 10,
+): (current: number, message?: string) => Promise<void> {
+  let lastReported = 0;
+
+  return async (current: number, message?: string) => {
+    // Report progress at throttle intervals or at completion
+    if (current - lastReported >= throttle || current === total) {
+      await sendProgress(ctx, current, total, message);
+      lastReported = current;
+    }
+  };
+}


### PR DESCRIPTION
## Summary

Implements real-time progress notifications for three long-running database operations following the stable MCP 2025-11-25 \
otifications/progress\ specification.

## Changes

### New Files
- \src/utils/progress-utils.ts\ — Utility module with \sendProgress()\, \uildProgressContext()\, and \createBatchProgressReporter()\

### Modified Files
- \src/types/index.ts\ — Extended \RequestContext\ with \server\ and \progressToken\ fields
- \src/adapters/sqlite/tools/admin.ts\ — Added progress to \sqlite_restore\ (3 phases) and \sqlite_optimize\ (dynamic phases)
- \src/adapters/sqlite/tools/virtual.ts\ — Added progress to \sqlite_vacuum\ (2 phases)
- \CHANGELOG.md\ — Documented feature in Unreleased section

## Progress Phases

| Tool | Phases |
|------|--------|
| \sqlite_restore\ | prepare → restore → verify |
| \sqlite_optimize\ | start → reindex (if enabled) → analyze (if enabled) → complete |
| \sqlite_vacuum\ | start → complete |

## Notes

Progress notifications require client support for \progressToken\ in request \_meta\. The infrastructure is in place; full functionality will be enabled when adapter tool registration is updated to use \server.registerTool()\ (matching memory-journal-mcp pattern).