### PR TITLE
refactor: Modernize tool registration to server.registerTool()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `sqlite_optimize`: Dynamic multi-phase progress (start → reindex → analyze → complete)
   - `sqlite_vacuum`: 2-phase progress (start → complete)
   - Notifications are best-effort and require client support for `progressToken` in `_meta`
+- **Modern Tool Registration** — Migrated from deprecated `server.tool()` to `server.registerTool()` API
+  - Both `SqliteAdapter` and `NativeSqliteAdapter` now use modern pattern
+  - Full `inputSchema`/`outputSchema` passed (not just `.shape`)
+  - MCP 2025-11-25 `structuredContent` returned when `outputSchema` is present
+  - Progress token extraction from `extra._meta` enables progress notifications
+  - Removed all eslint-disable comments for deprecated API usage
 
 ### Changed
 

--- a/src/adapters/DatabaseAdapter.ts
+++ b/src/adapters/DatabaseAdapter.ts
@@ -274,12 +274,26 @@ export abstract class DatabaseAdapter {
 
   /**
    * Create a request context for tool execution
+   * @param requestId Optional request ID for tracing
+   * @param server Optional MCP Server instance for progress notifications
+   * @param progressToken Optional progress token from client request _meta
    */
-  protected createContext(requestId?: string): RequestContext {
-    return {
+  protected createContext(
+    requestId?: string,
+    server?: unknown,
+    progressToken?: string | number,
+  ): RequestContext {
+    const context: RequestContext = {
       timestamp: new Date(),
       requestId: requestId ?? crypto.randomUUID(),
     };
+    if (server !== undefined) {
+      context.server = server;
+    }
+    if (progressToken !== undefined) {
+      context.progressToken = progressToken;
+    }
+    return context;
   }
 
   /**


### PR DESCRIPTION
## Summary

Migrates both SQLite adapters from the deprecated \server.tool()\ API to the modern \server.registerTool()\ pattern, enabling progress notifications and MCP 2025-11-25 compliance.

## Changes

### Core Infrastructure
- **DatabaseAdapter.ts**: Updated \createContext()\ to accept \server\ and \progressToken\ parameters
- **SqliteAdapter.ts**: Rewrote \egisterTool()\ with modern pattern
- **NativeSqliteAdapter.ts**: Same modernization

### Key Improvements

| Before | After |
|--------|-------|
| \server.tool()\ (deprecated) | \server.registerTool()\ |
| Extract \.shape\ from inputSchema | Pass full inputSchema/outputSchema |
| No \xtra\ parameter access | Extract \progressToken\ from \xtra._meta\ |
| Text-only responses | \structuredContent\ when outputSchema present |
| eslint-disable comments | Clean code |

## Benefits

✅ **Progress notifications now work** — \sqlite_restore\, \sqlite_optimize\, \sqlite_vacuum\ send real-time updates  
✅ **MCP 2025-11-25 compliance** — \structuredContent\ returned for tools with \outputSchema\  
✅ **Clean code** — Removed all deprecated API usage and eslint-disable comments  
✅ **Better error handling** — Consistent error response format with \isError: true\

## Verification

- ✅ \
pm run lint\ passes
- ✅ \
pm run typecheck\ passes
- ✅ \
pm run build\ succeeds