### PR TITLE
chore(deps): fix hono 4.11.7 moderate severity vulnerability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-- **Transitive Dependency Fixes** — Resolved high severity vulnerabilities via npm audit fix
+- **Transitive Dependency Fixes** — Resolved vulnerabilities via npm audit fix
+  - `hono`: 4.11.5 → 4.11.7 (moderate severity fix via `@modelcontextprotocol/sdk`)
 - **CodeQL Taint Tracking Fix** — Resolved static analysis alerts in logger
   - Fixed `js/clear-text-logging` by breaking data-flow path in `writeToStderr()`
   - Fixed `js/log-injection` by reconstructing output from static character codes

--- a/package-lock.json
+++ b/package-lock.json
@@ -2974,9 +2974,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.11.5",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.5.tgz",
-      "integrity": "sha512-WemPi9/WfyMwZs+ZUXdiwcCh9Y+m7L+8vki9MzDw3jJ+W9Lc+12HGsd368Qc1vZi1xwW8BWMMsnK5efYKPdt4g==",
+      "version": "4.11.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.7.tgz",
+      "integrity": "sha512-l7qMiNee7t82bH3SeyUCt9UF15EVmaBvsppY2zQtrbIhl/yzBTny+YUxsVjSjQ6gaqaeVtZmGocom8TzBlA4Yw==",
       "license": "MIT",
       "peer": true,
       "engines": {


### PR DESCRIPTION
## Summary
Fixes moderate severity vulnerability in hono (transitive dependency via @modelcontextprotocol/sdk).

## Changes
- Updated hono 4.11.5 → 4.11.7 via npm update
- Updated CHANGELOG.md with security fix

## Verification
- `npm audit` reports 0 vulnerabilities
- All lint and typecheck passes

## Related
- Supersedes #33 (Dependabot PR for same issue)