### PR TITLE
fix: JSONB support in NativeSqliteAdapter and JSONB-compatible collection tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `sqlite_create_table` message now accurately indicates when table already exists (using IF NOT EXISTS): "Table 'x' already exists (no changes made)"
   - `sqlite_list_tables` now correctly returns `columnCount` for each table (was always returning 0 in native adapter because `PRAGMA table_info()` was not being called)
 
+- **JSONB Support in Native Adapter** — Fixed JSONB detection missing in `NativeSqliteAdapter`
+  - `NativeSqliteAdapter.connect()` now detects SQLite version and sets JSONB support flag
+  - `sqlite_jsonb_convert` and other JSONB tools now work correctly with better-sqlite3 backend
+  - better-sqlite3 includes SQLite 3.51.2 which fully supports JSONB (requires 3.45+)
+
+- **JSONB-Compatible Collection Tables** — Updated `sqlite_create_json_collection` CHECK constraint
+  - Changed from `CHECK(json_valid("data"))` to `CHECK(json_type("data") IS NOT NULL)`
+  - `json_valid()` only works on text JSON; `json_type()` works on both text and JSONB formats
+  - Collections can now store JSONB data after `sqlite_jsonb_convert`
+
 ### Added
 
 - **Comprehensive Test Infrastructure** — Test database setup for systematic tool group testing

--- a/src/adapters/sqlite/tools/json-helpers.ts
+++ b/src/adapters/sqlite/tools/json-helpers.ts
@@ -473,7 +473,8 @@ function createJsonCollectionTool(adapter: SqliteAdapter): ToolDefinition {
       // Build CREATE TABLE
       const columns = [
         `"${idCol}" TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16))))`,
-        `"${dataCol}" TEXT NOT NULL CHECK(json_valid("${dataCol}"))`,
+        // Use json_type() IS NOT NULL instead of json_valid() to support both text JSON and JSONB
+        `"${dataCol}" TEXT NOT NULL CHECK(json_type("${dataCol}") IS NOT NULL)`,
       ];
 
       if (input.timestamps) {


### PR DESCRIPTION
## Summary

This PR fixes two JSONB-related issues discovered during comprehensive JSON tool group testing.

### Issue 1: JSONB Detection Missing in NativeSqliteAdapter

**Problem**: `sqlite_jsonb_convert` always reported "JSONB not supported (requires SQLite 3.45+)" even though better-sqlite3 bundles SQLite 3.51.2.

**Root Cause**: The `NativeSqliteAdapter` was missing the `setJsonbSupported()` call during initialization that existed in the WASM `SqliteAdapter`.

**Fix**: Added JSONB detection logic to `NativeSqliteAdapter.connect()` that queries SQLite version and sets the global JSONB support flag.

### Issue 2: sqlite_create_json_collection Blocks JSONB Storage

**Problem**: The CHECK constraint `CHECK(json_valid("data"))` fails when storing JSONB binary format because `json_valid()` only works on text JSON strings.

**Fix**: Changed to `CHECK(json_type("data") IS NOT NULL)` which validates both text JSON and JSONB formats.

### Testing

- All 350 tests pass
- Verified with live MCP server:
  - `jsonbSupported: true` confirmed
  - `sqlite_jsonb_convert` successfully converts rows
  - New collections can store JSONB data after conversion

### Files Changed

- `src/adapters/sqlite-native/NativeSqliteAdapter.ts` - Added JSONB detection
- `src/adapters/sqlite/tools/json-helpers.ts` - Updated CHECK constraint
- `CHANGELOG.md` - Documented fixes
