### PR TITLE
test: update native adapter version assertion 1.0.0 → 1.1.0

### DIFF
--- a/tests/adapters/sqlite-native/native-sqlite-adapter.test.ts
+++ b/tests/adapters/sqlite-native/native-sqlite-adapter.test.ts
@@ -34,7 +34,7 @@ describe("NativeSqliteAdapter", () => {
     });
 
     it("should return version", () => {
-      expect(adapter.version).toBe("1.0.0");
+      expect(adapter.version).toBe("1.1.0");
     });
 
     it("should identify as native backend", () => {


### PR DESCRIPTION
Fixes CI: updates the unit test assertion for NativeSqliteAdapter.version to match the 1.1.0 bump from PR #91.