### PR TITLE
test: derive adapter version from package.json

### DIFF
--- a/tests/adapters/sqlite-native/native-sqlite-adapter.test.ts
+++ b/tests/adapters/sqlite-native/native-sqlite-adapter.test.ts
@@ -8,6 +8,12 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { NativeSqliteAdapter } from "../../../src/adapters/sqlite-native/native-sqlite-adapter.js";
 import type { SqliteConfig } from "../../../src/adapters/sqlite/types.js";
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
+const { version: packageVersion } = require("../../../package.json") as {
+  version: string;
+};
 
 describe("NativeSqliteAdapter", () => {
   let adapter: NativeSqliteAdapter;
@@ -34,7 +40,7 @@ describe("NativeSqliteAdapter", () => {
     });
 
     it("should return version", () => {
-      expect(adapter.version).toBe("1.1.0");
+      expect(adapter.version).toBe(packageVersion);
     });
 
     it("should identify as native backend", () => {


### PR DESCRIPTION
Replaces hardcoded version assertion with package.json-derived value to prevent future CI breakage on version bumps.