### PR TITLE
v1.1.1 - Docker workflow fix, centralized version management

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -36,7 +36,7 @@ jobs:
           ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
       - name: Build image for scanning (local only)
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
@@ -132,7 +132,7 @@ jobs:
           ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
       - name: Log in to Docker Hub
         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
@@ -221,7 +221,7 @@ jobs:
           merge-multiple: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
       - name: Log in to Docker Hub
         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
@@ -264,7 +264,7 @@ jobs:
       # Update Docker Hub description
       - name: Update Docker Hub Description
         if: github.ref == 'refs/heads/main'
-        uses: peter-evans/dockerhub-description@37930b1c2abaa49bbe596cd826c3c89aef350131 # v5
+        uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5
         continue-on-error: true
         timeout-minutes: 5
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/neverinfamous/db-mcp/compare/v1.1.0...HEAD)
+## [Unreleased](https://github.com/neverinfamous/db-mcp/compare/v1.1.1...HEAD)
+
+## [1.1.1](https://github.com/neverinfamous/db-mcp/releases/tag/v1.1.1) - 2026-03-18
+
+### Fixed
+
+- **Docker Build**: Adjusted Docker/CI build configuration so `tsup` receives the correct inputs, fixing "No input files" CI build failure
+- **Docker Workflow**: Updated all `docker/setup-buildx-action` refs from v3 (Node 20, deprecated) to v4 (Node 24)
+- **Docker Workflow**: Fixed `peter-evans/dockerhub-description` broken SHA — updated to v5 release (`1b9a80c`)
+- **Prompt Handler**: Made `args` optional in `handleResult` to prevent crash when SDK invokes prompts with `undefined` args
+- **Transaction Methods**: Replaced generic `Error` with `ValidationError` + `INVALID_SAVEPOINT_NAME` code for savepoint name validation
+- **Index Tools**: Centralized table existence checks via `validateTableExists()` from `column-validation.ts`
+
+### Changed
+
+- **Version Management**: Both SQLite adapters now import `VERSION` from `src/version.ts` — only `package.json` needs updating on version bumps
+- **Version Test**: Derive expected adapter version from `VERSION` constant instead of hardcoded string
 
 ## [1.1.0](https://github.com/neverinfamous/db-mcp/releases/tag/v1.1.0) - 2026-03-18
 

--- a/DOCKER_README.md
+++ b/DOCKER_README.md
@@ -457,7 +457,7 @@ See [Keycloak Setup](https://github.com/neverinfamous/db-mcp/blob/main/docs/KEYC
 
 **Available Tags:**
 
-- `1.1.0` - Specific version (recommended for production)
+- `v1.1.1` - Specific version (recommended for production)
 - `latest` - Always the newest version
 - `sha-<commit>` - Git commit pinned
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "db-mcp",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "db-mcp",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "db-mcp",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "SQLite MCP server with OAuth 2.1 authentication, HTTP/SSE transport, and smart tool filtering",
   "mcpName": "io.github.neverinfamous/db-mcp",
   "type": "module",

--- a/releases/v1.1.1.md
+++ b/releases/v1.1.1.md
@@ -1,0 +1,31 @@
+# v1.1.1 - Docker Workflow Fix
+
+## Highlights
+
+- 🐳 Fixed Docker CI build failure and updated deprecated GitHub Actions to Node 24
+- 🔄 Centralized version management — adapters now import from `src/version.ts`
+- 🛡️ Hardened prompt handler, transaction validation, and index table checks
+
+## Fixed
+
+- **Docker Build**: Adjusted Docker/CI build configuration so `tsup` receives the correct inputs
+- **Docker Workflow**: All `docker/setup-buildx-action` refs v3 → v4 (Node 20 → 24)
+- **Docker Workflow**: `peter-evans/dockerhub-description` broken SHA → v5 (`1b9a80c`)
+- **Prompt Handler**: Optional `args` with `?? {}` default prevents crash on SDK `undefined`
+- **Transaction Methods**: `ValidationError` with `INVALID_SAVEPOINT_NAME` code replaces generic `Error`
+- **Index Tools**: Centralized `validateTableExists()` replaces inline `sqlite_master` checks
+
+## Changed
+
+- **Version Management**: Both adapters import `VERSION` from `src/version.ts` — only `package.json` needs updating on bumps
+- **Version Test**: Uses `VERSION` constant instead of hardcoded string
+
+---
+
+**Full Changelog**: [v1.1.0...v1.1.1](https://github.com/neverinfamous/db-mcp/compare/v1.1.0...v1.1.1)
+
+**Install**:
+```bash
+npm install db-mcp@1.1.1
+docker pull writenotenow/db-mcp:v1.1.1
+```

--- a/server.json
+++ b/server.json
@@ -3,19 +3,19 @@
   "name": "io.github.neverinfamous/db-mcp",
   "title": "db-mcp (SQLite MCP Server)",
   "description": "SQLite MCP server with OAuth 2.1, HTTP/SSE, 139 tools, and smart tool filtering",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "db-mcp",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "transport": {
         "type": "stdio"
       }
     },
     {
       "registryType": "oci",
-      "identifier": "docker.io/writenotenow/db-mcp:v1.1.0",
+      "identifier": "docker.io/writenotenow/db-mcp:v1.1.1",
       "transport": {
         "type": "stdio"
       }

--- a/src/adapters/sqlite-native/native-sqlite-adapter.ts
+++ b/src/adapters/sqlite-native/native-sqlite-adapter.ts
@@ -23,6 +23,7 @@ import type {
   ToolGroup,
 } from "../../types/index.js";
 import { logger, ERROR_CODES } from "../../utils/logger/index.js";
+import { VERSION } from "../../version.js";
 import {
   ConnectionError,
   ConfigurationError,
@@ -70,7 +71,7 @@ import {
 export class NativeSqliteAdapter extends DatabaseAdapter {
   readonly type: DatabaseType = "sqlite";
   readonly name = "Native SQLite Adapter (better-sqlite3)";
-  readonly version = "1.1.0";
+  readonly version = VERSION;
 
   /**
    * Check if this adapter uses native (better-sqlite3) backend.

--- a/src/adapters/sqlite/sqlite-adapter.ts
+++ b/src/adapters/sqlite/sqlite-adapter.ts
@@ -23,6 +23,7 @@ import type {
   ToolGroup,
 } from "../../types/index.js";
 import { ConnectionError } from "../../utils/errors/index.js";
+import { VERSION } from "../../version.js";
 import type { SqliteConfig } from "./types.js";
 import type { SchemaManager } from "./schema-manager.js";
 
@@ -56,7 +57,7 @@ import {
 export class SqliteAdapter extends DatabaseAdapter {
   override readonly type = "sqlite" as const;
   override readonly name = "SQLite Adapter";
-  override readonly version = "1.1.0"; // Keep in sync with package.json
+  override readonly version = VERSION;
 
   /**
    * Check if this adapter uses native (better-sqlite3) backend.

--- a/tests/adapters/sqlite-native/native-sqlite-adapter.test.ts
+++ b/tests/adapters/sqlite-native/native-sqlite-adapter.test.ts
@@ -8,12 +8,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { NativeSqliteAdapter } from "../../../src/adapters/sqlite-native/native-sqlite-adapter.js";
 import type { SqliteConfig } from "../../../src/adapters/sqlite/types.js";
-import { createRequire } from "module";
-
-const require = createRequire(import.meta.url);
-const { version: packageVersion } = require("../../../package.json") as {
-  version: string;
-};
+import { VERSION } from "../../../src/version.js";
 
 describe("NativeSqliteAdapter", () => {
   let adapter: NativeSqliteAdapter;
@@ -40,7 +35,7 @@ describe("NativeSqliteAdapter", () => {
     });
 
     it("should return version", () => {
-      expect(adapter.version).toBe(packageVersion);
+      expect(adapter.version).toBe(VERSION);
     });
 
     it("should identify as native backend", () => {


### PR DESCRIPTION
# v1.1.1 - Docker Workflow Fix

## Highlights

- 🐳 Fixed Docker CI build failure and updated deprecated GitHub Actions to Node 24
- 🔄 Centralized version management — adapters now import from `src/version.ts`
- 🛡️ Hardened prompt handler, transaction validation, and index table checks

## Fixed

- **Docker Build**: Adjusted Docker/CI build configuration so `tsup` receives the correct inputs
- **Docker Workflow**: All `docker/setup-buildx-action` refs v3 → v4 (Node 20 → 24)
- **Docker Workflow**: `peter-evans/dockerhub-description` broken SHA → v5 (`1b9a80c`)
- **Prompt Handler**: Optional `args` with `?? {}` default prevents crash on SDK `undefined`
- **Transaction Methods**: `ValidationError` with `INVALID_SAVEPOINT_NAME` code replaces generic `Error`
- **Index Tools**: Centralized `validateTableExists()` replaces inline `sqlite_master` checks

## Changed

- **Version Management**: Both adapters import `VERSION` from `src/version.ts` — only `package.json` needs updating on bumps
- **Version Test**: Uses `VERSION` constant instead of hardcoded string

---

**Full Changelog**: [v1.1.0...v1.1.1](https://github.com/neverinfamous/db-mcp/compare/v1.1.0...v1.1.1)

**Install**:
```bash
npm install db-mcp@1.1.1
docker pull writenotenow/db-mcp:v1.1.1
```
