### PR TITLE
fix(ci): use docker driver for security-scan buildx to fix Trivy image load

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -37,6 +37,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+        with:
+          driver: docker
 
       - name: Build image for scanning (local only)
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
@@ -47,8 +49,6 @@ jobs:
           push: false
           load: true
           tags: local-scan:latest
-          cache-from: type=gha,scope=linux/amd64
-          cache-to: type=gha,scope=linux/amd64,mode=max
 
       - name: Docker Scout security scan
         timeout-minutes: 10


### PR DESCRIPTION
The docker-container buildx driver (default) doesn't reliably support load: true for loading images into the local Docker daemon. Trivy fails with unable to find the specified image local-scan:latest.\n\n**Fix**: Use the docker driver for the security-scan job (single-platform amd64 only) and remove cache-from/cache-to GHA cache options which aren't supported by the docker driver.\n\nThe production multi-platform build jobs retain the docker-container driver with GHA caching.