### PR TITLE
fix(ci): raw docker build for Trivy scan, remove benchmarks

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -35,20 +35,8 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
-        with:
-          driver: docker
-
       - name: Build image for scanning (local only)
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
-        with:
-          context: .
-          file: Dockerfile
-          platforms: linux/amd64
-          push: false
-          load: true
-          tags: local-scan:latest
+        run: docker build --platform linux/amd64 -t local-scan:latest -f Dockerfile .
 
       - name: Docker Scout security scan
         timeout-minutes: 10

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -67,36 +67,4 @@ jobs:
       - name: Run npm audit
         run: npm audit --audit-level=moderate
 
-  benchmarks:
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: "24.x"
-          cache: "npm"
-
-      - name: Cache node_modules
-        id: cache-node-modules
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: node_modules
-          key: node-modules-24.x-${{ hashFiles('package-lock.json') }}
-
-      - name: Install dependencies
-        if: steps.cache-node-modules.outputs.cache-hit != 'true'
-        run: npm ci
-
-      - name: Run benchmarks
-        run: npm run bench 2>&1 | tee benchmark-results.txt
-
-      - name: Upload benchmark results
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: benchmark-results-${{ github.sha }}
-          path: benchmark-results.txt
-          retention-days: 30


### PR DESCRIPTION
Two CI fixes:

1. **Trivy scan**: Replace buildx uild-push-action with raw docker build for the security-scan job. Buildx's load: true fails to inject the image into the local daemon regardless of driver config. Raw docker build is the simplest reliable approach for single-platform local scanning.

2. **Remove benchmarks job**: Removes the enchmarks job from lint-and-test.yml. Benchmarks are useful for local development but add unnecessary CI runtime without gating value.