### PR TITLE
fix: resolve CodeQL alerts

### DIFF
--- a/DOCKER_README.md
+++ b/DOCKER_README.md
@@ -13,7 +13,7 @@ Production-ready SQLite MCP server with 151 tools, audit logging, OAuth 2.1, and
 [![TypeScript](https://img.shields.io/badge/TypeScript-Strict-blue.svg)](https://github.com/neverinfamous/db-mcp)
 [![E2E](https://github.com/neverinfamous/db-mcp/actions/workflows/e2e.yml/badge.svg)](https://github.com/neverinfamous/db-mcp/actions/workflows/e2e.yml)
 [![Tests](https://img.shields.io/badge/Tests-1911%20passed-brightgreen.svg)](https://github.com/neverinfamous/db-mcp)
-[![Coverage](https://img.shields.io/badge/Coverage-90.34%25-green.svg)](https://github.com/neverinfamous/db-mcp)
+[![Coverage](https://img.shields.io/badge/Coverage-90.39%25-green.svg)](https://github.com/neverinfamous/db-mcp)
 
 **[GitHub](https://github.com/neverinfamous/db-mcp)** • **[Wiki](https://github.com/neverinfamous/db-mcp/wiki)** • **[Changelog](https://github.com/neverinfamous/db-mcp/blob/main/CHANGELOG.md)**
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 [![TypeScript](https://img.shields.io/badge/TypeScript-Strict-blue.svg)](https://github.com/neverinfamous/db-mcp)
 [![E2E](https://github.com/neverinfamous/db-mcp/actions/workflows/e2e.yml/badge.svg)](https://github.com/neverinfamous/db-mcp/actions/workflows/e2e.yml)
 [![Tests](https://img.shields.io/badge/Tests-1911%20passed-brightgreen.svg)](https://github.com/neverinfamous/db-mcp)
-[![Coverage](https://img.shields.io/badge/Coverage-90.34%25-green.svg)](https://github.com/neverinfamous/db-mcp)
+[![Coverage](https://img.shields.io/badge/Coverage-90.39%25-green.svg)](https://github.com/neverinfamous/db-mcp)
 
 **[Wiki](https://github.com/neverinfamous/db-mcp/wiki)** • **[Changelog](CHANGELOG.md)**
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@modelcontextprotocol/sdk": "^1.27.1",
         "cors": "^2.8.5",
         "express": "^5.2.1",
+        "express-rate-limit": "^8.5.2",
         "jose": "^6.2.1",
         "sql.js": "^1.14.1",
         "zod": "^3.25.0 || ^4.0.0"

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@modelcontextprotocol/sdk": "^1.27.1",
     "cors": "^2.8.5",
     "express": "^5.2.1",
+    "express-rate-limit": "^8.5.2",
     "jose": "^6.2.1",
     "sql.js": "^1.14.1",
     "zod": "^3.25.0 || ^4.0.0"

--- a/src/transports/http/middleware.ts
+++ b/src/transports/http/middleware.ts
@@ -6,6 +6,7 @@
  */
 
 import cors from "cors";
+import rateLimit from "express-rate-limit";
 import type { Request, Response, RequestHandler } from "express";
 import {
   DEFAULT_RATE_LIMIT_WINDOW_MS,
@@ -139,7 +140,6 @@ export function setupCors(state: HttpTransportState): void {
   }
 }
 
-import rateLimit from "express-rate-limit";
 
 // =============================================================================
 // Rate Limiting
@@ -167,7 +167,6 @@ export function setupRateLimiting(state: HttpTransportState): void {
     handler: (_req, res, _next, options) => {
       res.status(options.statusCode).json({
         error: "Too Many Requests",
-        retryAfter: Math.ceil(windowMs / 1000),
       });
     },
   });

--- a/src/transports/http/middleware.ts
+++ b/src/transports/http/middleware.ts
@@ -139,12 +139,14 @@ export function setupCors(state: HttpTransportState): void {
   }
 }
 
+import rateLimit from "express-rate-limit";
+
 // =============================================================================
 // Rate Limiting
 // =============================================================================
 
 /**
- * Set up per-IP sliding-window rate limiting
+ * Set up per-IP sliding-window rate limiting using express-rate-limit
  */
 export function setupRateLimiting(state: HttpTransportState): void {
   if (!state.app) return;
@@ -155,46 +157,20 @@ export function setupRateLimiting(state: HttpTransportState): void {
     : DEFAULT_RATE_LIMIT_MAX;
   const trustProxy = state.config.trustProxy ?? false;
 
-  // Periodic cleanup of expired entries
-  state.rateLimitCleanupTimer = setInterval(() => {
-    const now = Date.now();
-    for (const [ip, entry] of state.rateLimitMap) {
-      if (now >= entry.resetAt) {
-        state.rateLimitMap.delete(ip);
-      }
-    }
-  }, windowMs);
-  // Don't block process exit
-  state.rateLimitCleanupTimer.unref();
-
-  state.app.use((req: Request, res: Response, next: () => void) => {
-    // Skip rate limiting for health checks
-    if (req.path === "/health") {
-      next();
-      return;
-    }
-
-    const ip = getClientIp(req, trustProxy);
-    const now = Date.now();
-    let entry = state.rateLimitMap.get(ip);
-
-    if (!entry || now >= entry.resetAt) {
-      entry = { count: 0, resetAt: now + windowMs };
-      state.rateLimitMap.set(ip, entry);
-    }
-
-    entry.count++;
-
-    if (entry.count > maxRequests) {
-      const retryAfter = Math.ceil((entry.resetAt - now) / 1000);
-      res.setHeader("Retry-After", String(retryAfter));
-      res.status(429).json({
+  const limiter = rateLimit({
+    windowMs,
+    max: maxRequests,
+    standardHeaders: true,
+    legacyHeaders: false,
+    keyGenerator: (req) => getClientIp(req, trustProxy),
+    skip: (req) => req.path === "/health",
+    handler: (_req, res, _next, options) => {
+      res.status(options.statusCode).json({
         error: "Too Many Requests",
-        retryAfter,
+        retryAfter: Math.ceil(windowMs / 1000),
       });
-      return;
-    }
-
-    next();
+    },
   });
+
+  state.app.use(limiter);
 }

--- a/src/transports/http/transport.ts
+++ b/src/transports/http/transport.ts
@@ -26,7 +26,6 @@ import {
   HTTP_HEADERS_TIMEOUT_MS,
   type HttpTransportConfig,
   type HttpTransportState,
-  type RateLimitEntry,
 } from "./types.js";
 import {
   setupSecurityHeaders,
@@ -85,8 +84,6 @@ export class HttpTransport {
       authServerDiscovery: null,
       tokenValidator: null,
       mcpServer: null,
-      rateLimitMap: new Map<string, RateLimitEntry>(),
-      rateLimitCleanupTimer: null,
     };
   }
 
@@ -276,12 +273,6 @@ export class HttpTransport {
    * Stop the server and close all active sessions
    */
   async stop(): Promise<void> {
-    // Stop rate limit cleanup timer
-    if (this.state.rateLimitCleanupTimer) {
-      clearInterval(this.state.rateLimitCleanupTimer);
-      this.state.rateLimitCleanupTimer = null;
-    }
-
     // Close all active Streamable HTTP transports
     for (const [sessionId, transport] of this.state.transports) {
       try {

--- a/src/transports/http/types.ts
+++ b/src/transports/http/types.ts
@@ -18,10 +18,6 @@ import type { Express } from "express";
 // Rate Limiting
 // =============================================================================
 
-export interface RateLimitEntry {
-  count: number;
-  resetAt: number;
-}
 
 export const DEFAULT_RATE_LIMIT_WINDOW_MS = 60_000;
 export const DEFAULT_RATE_LIMIT_MAX = 100;
@@ -168,7 +164,4 @@ export interface HttpTransportState {
   // Reference to the MCP server for stateful connections
   mcpServer: McpServer | null;
 
-  // Rate limiting state
-  rateLimitMap: Map<string, RateLimitEntry>;
-  rateLimitCleanupTimer: ReturnType<typeof setInterval> | null;
 }

--- a/tests/adapters/sqlite/tools/virtual/analysis.test.ts
+++ b/tests/adapters/sqlite/tools/virtual/analysis.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import {
   createDbStatTool,
   createVacuumTool,

--- a/tests/transports/http-middleware.test.ts
+++ b/tests/transports/http-middleware.test.ts
@@ -272,7 +272,7 @@ describe("setupRateLimiting", () => {
     vi.restoreAllMocks();
   });
 
-  it("should allow requests under the limit", () => {
+  it("should allow requests under the limit", async () => {
     const state = createMockState();
     setupRateLimiting(state);
 
@@ -281,15 +281,12 @@ describe("setupRateLimiting", () => {
     const res = createMockRes();
     const next = vi.fn();
 
-    middleware(req, res, next);
+    await middleware(req, res, next);
 
     expect(next).toHaveBeenCalled();
-
-    // Clean up timer
-    if (state.rateLimitCleanupTimer) clearInterval(state.rateLimitCleanupTimer);
   });
 
-  it("should bypass rate limit for /health path", () => {
+  it("should bypass rate limit for /health path", async () => {
     const state = createMockState();
     setupRateLimiting(state);
 
@@ -298,11 +295,9 @@ describe("setupRateLimiting", () => {
     const res = createMockRes();
     const next = vi.fn();
 
-    middleware(req, res, next);
+    await middleware(req, res, next);
 
     expect(next).toHaveBeenCalled();
-
-    if (state.rateLimitCleanupTimer) clearInterval(state.rateLimitCleanupTimer);
   });
 
   it("should not throw when app is null", () => {


### PR DESCRIPTION
Fixes two CodeQL alerts:

1. \js/missing-rate-limiting\ - Replaced custom rate limiting middleware with standard \express-rate-limit\ to satisfy CodeQL heuristics.
2. \js/unused-local-variable\ - Removed unused \eforeEach\ import from tests.

All tests and types pass locally.