### PR TITLE
ci: fix gatekeeper workflow permissions

### DIFF
--- a/.github/workflows/gatekeeper.yml
+++ b/.github/workflows/gatekeeper.yml
@@ -58,6 +58,7 @@ jobs:
       contents: read
       security-events: write
       id-token: write
+      packages: write
       attestations: write
     secrets:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
Fix missing packages: write permission in gatekeeper for docker-publish.